### PR TITLE
fix: resolve ESM/CJS import issue in Next.js config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "brease-next",
   "version": "0.1.8",
+  "type": "module",
   "description": "Brease CMS integration for Next.js - React components, hooks, and utilities for seamless content management",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,14 +1,14 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/**/*.{ts,tsx}'],
+  entry: ['src/index.ts', 'src/server.ts'],
   format: ['cjs', 'esm'],
   dts: true,
   sourcemap: true,
   clean: true,
-  bundle: false,
+  bundle: true,
   splitting: false,
-  treeshake: false,
+  treeshake: true,
   outDir: 'dist',
   outExtension({ format }) {
     return {


### PR DESCRIPTION
## Summary
- Fixes ESM import failure in `next.config.mjs` `redirects()` function
- Changes tsup config to bundle entry points instead of preserving file structure
- Adds `"type": "module"` to package.json to eliminate Node.js warnings

## Root Cause
With `bundle: false` in tsup config, CJS outputs incorrectly referenced `.js` files (e.g., `require("./api.js")`) instead of `.cjs` files, causing import failures.

## Changes
- `tsup.config.ts`: Changed `entry` from glob pattern to explicit entry points, enabled `bundle: true` and `treeshake: true`
- `package.json`: Added `"type": "module"`

## Test Plan
- [x] Build succeeds with new config
- [x] CJS import works in Node.js
- [x] ESM import works in `next.config.mjs`
- [x] No MODULE_TYPELESS_PACKAGE_JSON warning

Closes #2